### PR TITLE
fix: 회원가입 시 이메일 중복 체크 로직 추가

### DIFF
--- a/src/main/java/io/jeidiiy/outflearn/common/advice/ExceptionRestControllerAdvice.java
+++ b/src/main/java/io/jeidiiy/outflearn/common/advice/ExceptionRestControllerAdvice.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import io.jeidiiy.outflearn.common.exception.EmailDuplicateException;
 import io.jeidiiy.outflearn.common.exception.ResourceNotFoundException;
 import io.jeidiiy.outflearn.common.exception.VerificationCodeNotMatchedException;
 
@@ -31,6 +32,13 @@ public class ExceptionRestControllerAdvice {
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(VerificationCodeNotMatchedException.class)
 	public String verificationCodeNotMatchedException(VerificationCodeNotMatchedException exception) {
+		return exception.getMessage();
+	}
+
+	@ResponseBody
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(EmailDuplicateException.class)
+	public String duplicateEmail(EmailDuplicateException exception) {
 		return exception.getMessage();
 	}
 

--- a/src/main/java/io/jeidiiy/outflearn/common/exception/EmailDuplicateException.java
+++ b/src/main/java/io/jeidiiy/outflearn/common/exception/EmailDuplicateException.java
@@ -1,0 +1,7 @@
+package io.jeidiiy.outflearn.common.exception;
+
+public class EmailDuplicateException extends RuntimeException {
+	public EmailDuplicateException() {
+		super("이미 가입된 이메일입니다. 다른 이메일을 사용해 주세요");
+	}
+}

--- a/src/test/java/io/jeidiiy/outflearn/user/service/UserServiceImplTest.java
+++ b/src/test/java/io/jeidiiy/outflearn/user/service/UserServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.jeidiiy.outflearn.common.exception.EmailDuplicateException;
 import io.jeidiiy.outflearn.common.exception.VerificationCodeNotMatchedException;
 import io.jeidiiy.outflearn.mock.FakeMailSender;
 import io.jeidiiy.outflearn.mock.FakeUserRepository;
@@ -29,16 +30,16 @@ class UserServiceImplTest {
 			.build();
 		fakeUserRepository.save(User.builder()
 			.id(1L)
-			.email("kok202@naver.com")
-			.nickname("kok202")
+			.email("tooth@gmail.com")
+			.nickname("test")
 			.verificationCode("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
 			.status(UserStatus.ACTIVE)
 			.lastLoginAt(0L)
 			.build());
 		fakeUserRepository.save(User.builder()
 			.id(2L)
-			.email("kok303@naver.com")
-			.nickname("kok303")
+			.email("toast@gmail.com")
+			.nickname("toast")
 			.verificationCode("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab")
 			.status(UserStatus.PENDING)
 			.lastLoginAt(0L)
@@ -70,5 +71,18 @@ class UserServiceImplTest {
 		assertThatThrownBy(() -> {
 			userService.verifyEmail(2L, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaac");
 		}).isInstanceOf(VerificationCodeNotMatchedException.class);
+	}
+
+	@Test
+	void 같은_이메일로_회원가입하면_예외를_던진다() {
+		// given
+		UserCreate userCreate = UserCreate.builder()
+			.email("toast@gmail.com")
+			.build();
+
+		// when
+		// then
+		assertThatThrownBy(() -> userService.create(userCreate))
+			.isInstanceOf(EmailDuplicateException.class);
 	}
 }


### PR DESCRIPTION
# What is this PR?🔍

- 회원가입 시 같은 이메일로 회원가입하지 못하도록 중복을 체크하는 로직을 추가하여 문제를 수정했습니다.

## Test Checklist✅

- [x] 같은_이메일로_회원가입하면_예외를_던진다
