### PR TITLE
fix: 세션에 인증 객체가 저장되지 않는 오류 수정

### DIFF
--- a/src/main/java/io/jeidiiy/outflearn/security/config/SecurityConfig.java
+++ b/src/main/java/io/jeidiiy/outflearn/security/config/SecurityConfig.java
@@ -33,6 +33,12 @@ public class SecurityConfig {
 
 		http.apply(ajaxLoginConfigurer());
 
+		http
+			.securityContext(
+				securityContext ->
+					securityContext.requireExplicitSave(false)
+			);
+
 		return http.build();
 	}
 


### PR DESCRIPTION
# What is this PR?🔍

- HttpSession에 인증 객체가 저장되지 않는 오류를 수정했습니다.

## Changes📝

- Spring Security 6 버전 이후부터는 기본적으로 SecurityContextPersistenceFilter가 아닌 **SecurityContextHolderFilter**가 적용됩니다. 기존에는 흐름 중간에 Response가 commit된 상황에 대한 문제가 있었고 이를 위해 개발되었습니다.
- 이 때문에 SecurityContextRepository에 명시적으로 저장을 해주어야 합니다. 이 PR에서는 이를 SecurityContextPersistenceFilter를 사용하는 방법으로 해결하였습니다.
